### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open("README", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="zvm", # Replace with your own username
+    version="1.0.0",
+    author="Ben Collins-Sussman",
+    author_email="sussman@gmail.com",
+    description="A pure-python implementation of a Z-machine for interactive fiction",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    url="https://github.com/sussman/zvm",
+    project_urls={
+        "Bug Tracker": "https://github.com/sussman/zvm/issues",
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Topic :: Games/Entertainment",
+    ],
+    packages=setuptools.find_packages(include=["zvm"]),
+    python_requires=">=3.6",
+)


### PR DESCRIPTION
This adds a setup.py file, which makes it possible to install in an editable fashion:

```bash
cd zvm
pip install -e .
```

Subsequent edits show up immediately.  This does not build or install `cheapglk`, and it may be a good idea to expand it to install the sample stories with `package_data`.

I took a few liberties, including with the version.
