### PR TITLE
add compatibility for Windows

### DIFF
--- a/cheapglk/Makefile
+++ b/cheapglk/Makefile
@@ -10,11 +10,17 @@
 # CC = cc
 CC = gcc -ansi
 
-OPTIONS = -g -Wall -fPIC
-
-CFLAGS = $(OPTIONS) $(INCLUDEDIRS)
-
 GLKLIB_SHARED = libcheapglk.so
+OSFLAG :=
+DEL := rm -f
+ifeq ($(OS),Windows_NT)
+OSFLAG := -D WIN32
+GLKLIB_SHARED = libcheapglk.dll
+DEL := del /F
+endif
+
+OPTIONS = -g -Wall -fPIC
+CFLAGS = $(OPTIONS) $(INCLUDEDIRS) $(OSFLAG)
 
 CHEAPGLK_OBJS =  \
   cgfref.o cggestal.o cgmisc.o cgstream.o cgstyle.o cgwindow.o cgschan.o \
@@ -33,4 +39,4 @@ $(GLKLIB_SHARED): $(CHEAPGLK_OBJS)
 $(CHEAPGLK_OBJS): glk.h $(CHEAPGLK_HEADERS)
 
 clean:
-	rm -f *~ *.o $(GLKLIB_SHARED)
+	$(DEL) *~ *.o $(GLKLIB_SHARED)

--- a/cheapglk/cgdate.c
+++ b/cheapglk/cgdate.c
@@ -45,8 +45,11 @@ static void gli_date_from_tm(glkdate_t *date, struct tm *tm)
 static glsi32 gli_date_to_tm(glkdate_t *date, struct tm *tm)
 {
     glsi32 microsec;
-
-    bzero(tm, sizeof(*tm));
+#ifdef WIN32
+	 memset(tm, 0, sizeof(*tm));
+#else
+	 bzero(tm, sizeof(*tm));
+#endif
     tm->tm_year = date->year - 1900;
     tm->tm_mon = date->month - 1;
     tm->tm_mday = date->day;


### PR DESCRIPTION
Tested with MinGW32 (10.3) and 32bit Python 3.11 builds ok and checks running fine.
Under MinGW64 and Python 64 getting strange compile errors for cheapglk.